### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,5 @@
     "mocha": "1.x.x",
     "proxyquire": "^1.4.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
